### PR TITLE
允许连接到北邮人

### DIFF
--- a/reality/Dockerfile
+++ b/reality/Dockerfile
@@ -1,7 +1,7 @@
 # builder
 FROM golang:alpine AS builder
 LABEL maintainer="wulabing <wulabing@gmail.com>"
-LABEL version="0.0.25"
+LABEL version="0.0.26"
 
 
 #ENV GOPROXY=https://goproxy.cn,direct

--- a/reality/config.json
+++ b/reality/config.json
@@ -100,6 +100,13 @@
       },
       {
         "domain": [
+          "domain:byr.pt"
+        ],
+        "type": "field",
+        "outboundTag": "direct"
+      },
+      {
+        "domain": [
           "domain:iqiyi.com",
           "domain:video.qq.com",
           "domain:youku.com"


### PR DESCRIPTION
北邮人主站封锁了国内运营商的ipv6，因此需要从国外ipv6翻回去。在配置中添加特例以允许这一点